### PR TITLE
chore: enable all disabled oxlint TODO rules

### DIFF
--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -77,8 +77,7 @@ export default defineConfig({
     // refactoring to standalone functions would lose the encapsulation
     'typescript/no-extraneous-class': 'off',
 
-    // TODO: re-enable and fix — unsafe type assertions are used throughout
-    'typescript/no-unsafe-type-assertion': 'off',
+    'typescript/no-unsafe-type-assertion': 'warn',
 
     'typescript/no-unnecessary-type-arguments': 'warn',
 

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -66,8 +66,7 @@ export default defineConfig({
     // accidental thenable (it is never used in await expressions)
     'unicorn/no-thenable': 'off',
 
-    // TODO: re-enable and fix — spread-in-for-of is a minor perf issue
-    'unicorn/no-useless-spread': 'off',
+    'unicorn/no-useless-spread': 'warn',
 
     // TODO: re-enable and fix — no-shadow fires in many places with valid patterns
     'no-shadow': 'off',
@@ -84,8 +83,7 @@ export default defineConfig({
     // TODO: re-enable and fix — unnecessary type arguments are minor style issues
     'typescript/no-unnecessary-type-arguments': 'off',
 
-    // TODO: re-enable and fix — unnecessary type assertion is minor
-    'typescript/no-unnecessary-type-assertion': 'off',
+    'typescript/no-unnecessary-type-assertion': 'warn',
 
     // TODO: re-enable and fix — unnecessary type conversion (.toString() on string)
     'typescript/no-unnecessary-type-conversion': 'off',

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -74,7 +74,8 @@ export default defineConfig({
     // TODO: re-enable and fix — consistent-return fires in spawn-manager routines
     'typescript/consistent-return': 'off',
 
-    // TODO: re-enable and fix — no-extraneous-class fires for ErrorMapper static class
+    // ErrorMapper is a static-only utility class with cached state —
+    // refactoring to standalone functions would lose the encapsulation
     'typescript/no-extraneous-class': 'off',
 
     // TODO: re-enable and fix — unsafe type assertions are used throughout
@@ -85,10 +86,8 @@ export default defineConfig({
 
     'typescript/no-unnecessary-type-assertion': 'warn',
 
-    // TODO: re-enable and fix — unnecessary type conversion (.toString() on string)
-    'typescript/no-unnecessary-type-conversion': 'off',
+    'typescript/no-unnecessary-type-conversion': 'warn',
 
-    // TODO: re-enable and fix — default assignment in destructuring is valid intent
-    'typescript/no-useless-default-assignment': 'off',
+    'typescript/no-useless-default-assignment': 'warn',
   },
 });

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -71,8 +71,7 @@ export default defineConfig({
     // TODO: re-enable and fix — no-shadow fires in many places with valid patterns
     'no-shadow': 'off',
 
-    // TODO: re-enable and fix — consistent-return fires in spawn-manager routines
-    'typescript/consistent-return': 'off',
+    'typescript/consistent-return': 'warn',
 
     // ErrorMapper is a static-only utility class with cached state —
     // refactoring to standalone functions would lose the encapsulation

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -68,8 +68,7 @@ export default defineConfig({
 
     'unicorn/no-useless-spread': 'warn',
 
-    // TODO: re-enable and fix — no-shadow fires in many places with valid patterns
-    'no-shadow': 'off',
+    'no-shadow': 'warn',
 
     'typescript/consistent-return': 'warn',
 

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -81,8 +81,7 @@ export default defineConfig({
     // TODO: re-enable and fix — unsafe type assertions are used throughout
     'typescript/no-unsafe-type-assertion': 'off',
 
-    // TODO: re-enable and fix — unnecessary type arguments are minor style issues
-    'typescript/no-unnecessary-type-arguments': 'off',
+    'typescript/no-unnecessary-type-arguments': 'warn',
 
     'typescript/no-unnecessary-type-assertion': 'warn',
 

--- a/packages/bot/src/library/RectangleArray.ts
+++ b/packages/bot/src/library/RectangleArray.ts
@@ -24,6 +24,7 @@ export class RectangleArray {
     );
   }
   public toCostMatrix(): CostMatrix {
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- accessing internal CostMatrix _bits
     const cm = new PathFinder.CostMatrix() as CostMatrix & {
       _bits: Uint8Array;
     };

--- a/packages/bot/src/library/coordinates.ts
+++ b/packages/bot/src/library/coordinates.ts
@@ -76,6 +76,7 @@ export class CoordinateSet {
   }
 
   private unhash(p: string): Coordinates {
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- tuple from split
     return p.split(',').map(Number.parseFloat) as Coordinates;
   }
 
@@ -127,6 +128,7 @@ export class CoordinateAdjacencyList {
   }
 
   private unhash(p: string): Coordinates {
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- tuple from split
     return p.split(',').map(Number.parseFloat) as Coordinates;
   }
 

--- a/packages/bot/src/library/delaunay.ts
+++ b/packages/bot/src/library/delaunay.ts
@@ -35,6 +35,7 @@ const pointsOfTriangle = (
   delaunay: DelaunatorLike,
   t: number,
 ): [number, number, number] => {
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- tuple from map
   return edgesOfTriangle(t).map((e) => delaunay.triangles[e]) as [
     number,
     number,
@@ -47,6 +48,7 @@ const triangleCenter = (
   delaunay: DelaunatorLike,
   t: number,
 ): Coordinates => {
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- tuple from map
   const vertices = pointsOfTriangle(delaunay, t).map((p) => points[p]) as [
     Coordinates,
     Coordinates,

--- a/packages/bot/src/library/logger.ts
+++ b/packages/bot/src/library/logger.ts
@@ -50,6 +50,7 @@ registerCommand('setLogLevel', (level) => {
     throw new InvalidArgumentError('LogLevel', level);
   }
 
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by `in` check above
   settingsRef.level = LogLevel[level.toLowerCase() as keyof typeof LogLevel];
   return undefined;
 });

--- a/packages/bot/src/library/memory.ts
+++ b/packages/bot/src/library/memory.ts
@@ -12,6 +12,7 @@ export const getMemoryRef = <T>(
 
   return {
     get() {
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion -- intentional type erasure for dynamic memory access
       return Memory[key] as never;
     },
     set(value) {

--- a/packages/bot/src/library/rtree.ts
+++ b/packages/bot/src/library/rtree.ts
@@ -33,6 +33,7 @@ export class RTree extends RBush<Coordinates> {
     point: Coordinates;
     distance: number;
   } | null {
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- accessing internal rbush data structure
     let node = (this as unknown as { data: Node<Coordinates> }).data;
     const queue = new Queue<
       { dist: number } & (

--- a/packages/bot/src/library/sleep.ts
+++ b/packages/bot/src/library/sleep.ts
@@ -19,9 +19,9 @@ export const resolveSleep = () => {
 export const sleep = (ticks: number = 1): Future<void> => {
   const wakeTime = Game.time + ticks;
 
-  const sleep = sleepers.get(wakeTime);
-  if (sleep !== undefined) {
-    return sleep.future;
+  const existing = sleepers.get(wakeTime);
+  if (existing !== undefined) {
+    return existing.future;
   }
 
   const [future, resolve] = Future.defer<void>();

--- a/packages/bot/src/library/stats.ts
+++ b/packages/bot/src/library/stats.ts
@@ -25,6 +25,7 @@ export const recordStats = (stats: StatsRecord) => {
 
 export const recordGlobals = () => {
   const rooms = _.mapValues(
+    // eslint-disable-next-line typescript/no-unnecessary-type-arguments -- TS requires both type params for this overload
     _.pick<Record<string, Room>, Record<string, Room>>(
       Game.rooms,
       (room: Room) => room.controller?.my

--- a/packages/bot/src/main.ts
+++ b/packages/bot/src/main.ts
@@ -31,7 +31,7 @@ export const loop = ErrorMapper.wrapLoop(
 
     const visuals = new RoomVisual();
     Object.entries(cpuUsage).forEach(([name, usage], index) => {
-      visuals.text(`${name}: ${usage.toFixed(2).toString()}`, 49, index + 0.2, {
+      visuals.text(`${name}: ${usage.toFixed(2)}`, 49, index + 0.2, {
         font: 0.7,
         align: 'right',
       });

--- a/packages/bot/src/polyfills/RoomVisual.ts
+++ b/packages/bot/src/polyfills/RoomVisual.ts
@@ -535,7 +535,7 @@ RoomVisual.prototype.connectRoads = function (opts = {}) {
     for (let i = 1; i <= 4; i++) {
       const d = dirs[i]!;
       const c = [r[0] + d[0]!, r[1] + d[1]!];
-      const rd = _.some(this.roads, (r) => r[0] == c[0] && r[1] == c[1]);
+      const rd = _.some(this.roads, (other) => other[0] == c[0] && other[1] == c[1]);
       if (rd) {
         this.line(r[0], r[1], c[0]!, c[1]!, {
           color: color,

--- a/packages/bot/src/routines/creep-manager.ts
+++ b/packages/bot/src/routines/creep-manager.ts
@@ -79,7 +79,7 @@ function* runMiner(id: Id<Creep>) {
       return;
     }
 
-    const [x, y, roomName = miner.room.name] = miner.memory.slot;
+    const [x, y, roomName] = miner.memory.slot;
     const target = new RoomPosition(x, y, roomName);
     if (!miner.pos.isEqualTo(target)) {
       miner.moveTo(target, {

--- a/packages/bot/src/routines/hauler.ts
+++ b/packages/bot/src/routines/hauler.ts
@@ -68,7 +68,7 @@ const pickupEnergy = (hauler: Creep, need: number, includeContainer = true) => {
   const target =
     targetPath.incomplete || !targetPos
       ? null
-      : targets.find((target) => target.pos.isEqualTo(targetPos));
+      : targets.find((t) => t.pos.isEqualTo(targetPos));
 
   if (!target) {
     return;

--- a/packages/bot/src/routines/hauler.ts
+++ b/packages/bot/src/routines/hauler.ts
@@ -106,6 +106,7 @@ const PriorityMap = {
 type HaulerTarget = ConcreteStructure<keyof typeof PriorityMap>;
 
 const isHaulerTarget = isStructureType(
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- Object.keys loses literal type
   ...(Object.keys(PriorityMap) as HaulerTarget['structureType'][]),
 );
 

--- a/packages/bot/src/routines/link-manager.ts
+++ b/packages/bot/src/routines/link-manager.ts
@@ -18,13 +18,13 @@ export function* linkManager(roomName: string) {
 
   for (;;) {
     yield sleep();
-    const room = Game.rooms[roomName];
-    if (!room || !room.controller) {
+    const currentRoom = Game.rooms[roomName];
+    if (!currentRoom || !currentRoom.controller) {
       return;
     }
 
-    const { storage, controller } = room;
-    const links = room
+    const { storage, controller } = currentRoom;
+    const links = currentRoom
       .find(FIND_MY_STRUCTURES)
       .filter(isStructureType(STRUCTURE_LINK));
 

--- a/packages/bot/src/routines/plan-room.ts
+++ b/packages/bot/src/routines/plan-room.ts
@@ -121,8 +121,8 @@ const getBuildingSpace = (room: Room): CostMatrix => {
 
   // Block off tiles around exit tiles.
   for (const { x, y } of room.find(FIND_EXIT)) {
-    [[x, y] as Coordinates, ...expandPosition([x, y])].forEach(([x, y]) =>
-      cm.set(x, y, 1),
+    [[x, y] as Coordinates, ...expandPosition([x, y])].forEach(([cx, cy]) =>
+      cm.set(cx, cy, 1),
     );
   }
 
@@ -130,16 +130,16 @@ const getBuildingSpace = (room: Room): CostMatrix => {
   for (const {
     pos: { x, y },
   } of [...room.find(FIND_SOURCES), ...room.find(FIND_MINERALS)]) {
-    [[x, y] as Coordinates, ...expandPosition([x, y])].forEach(([x, y]) =>
-      cm.set(x, y, BlockedCost),
+    [[x, y] as Coordinates, ...expandPosition([x, y])].forEach(([cx, cy]) =>
+      cm.set(cx, cy, BlockedCost),
     );
   }
 
   // Block off tiles around controller.
   if (room.controller) {
     const { x, y } = room.controller.pos;
-    [[x, y] as Coordinates, ...expandPosition([x, y])].forEach(([x, y]) =>
-      cm.set(x, y, BlockedCost),
+    [[x, y] as Coordinates, ...expandPosition([x, y])].forEach(([cx, cy]) =>
+      cm.set(cx, cy, BlockedCost),
     );
   }
 
@@ -519,16 +519,16 @@ export function* planRoom(roomName: string): Routine {
     yield;
 
     for (;;) {
-      const room = Game.rooms[roomName];
-      if (!room) {
+      const currentRoom = Game.rooms[roomName];
+      if (!currentRoom) {
         return;
       }
       // room.visual.import(
       //   overlayCostMatrix(distanceTransform, (dist) => dist / 13)
       // );
       // room.visual.import(overlayCostMatrix(buildingSpace));
-      room.visual.import(buildingVisuals);
-      room.visual.circle(...origin, {
+      currentRoom.visual.import(buildingVisuals);
+      currentRoom.visual.circle(...origin, {
         fill: 'green',
         radius: 0.25,
       });
@@ -571,22 +571,22 @@ export function* planRoom(roomName: string): Routine {
       });
 
     while (toBePlaced.length > 0) {
-      const room = Game.rooms[roomName];
-      if (!room) {
+      const currentRoom = Game.rooms[roomName];
+      if (!currentRoom) {
         return;
       }
       if (
-        room.find(FIND_MY_CONSTRUCTION_SITES).length >= MaxConstructionSites
+        currentRoom.find(FIND_MY_CONSTRUCTION_SITES).length >= MaxConstructionSites
       ) {
         yield sleep();
         continue;
       }
-      const controller = room.controller;
+      const controller = currentRoom.controller;
       if (!controller) {
         return;
       }
 
-      const placement = nextStructure(room, toBePlaced);
+      const placement = nextStructure(currentRoom, toBePlaced);
 
       if (!placement) {
         const start = controller.level;

--- a/packages/bot/src/routines/room-knowledge.ts
+++ b/packages/bot/src/routines/room-knowledge.ts
@@ -254,7 +254,7 @@ function* labelComponents(
   return contours;
 }
 
-function* pruneMedials(graph: RegionGraph, rtree: RTree): Routine<void> {
+function* pruneMedials(graph: RegionGraph, rtree: RTree): Routine {
   const candidates = new Set(
     Array.from(graph).filter(({ size }) => size === 1),
   );
@@ -275,7 +275,7 @@ function* pruneMedials(graph: RegionGraph, rtree: RTree): Routine<void> {
   }
 }
 
-function* addSinks(graph: RegionGraph): Routine<void> {
+function* addSinks(graph: RegionGraph): Routine {
   const nodes = Array.from(graph).filter(
     ({ coordinates: [x, y] }) => x < 2 || x > 48 || y < 2 || y > 48,
   );
@@ -289,7 +289,7 @@ function* addSinks(graph: RegionGraph): Routine<void> {
   }
 }
 
-function* identifyNodes(graph: RegionGraph, rtree: RTree): Routine<void> {
+function* identifyNodes(graph: RegionGraph, rtree: RTree): Routine {
   const candidates = new Set(
     Array.from(graph).filter(({ size }) => size === 1),
   );

--- a/packages/bot/src/routines/room-knowledge.ts
+++ b/packages/bot/src/routines/room-knowledge.ts
@@ -433,6 +433,7 @@ export function* roomKnowledge(roomName: string) {
   const delaunay = new Delaunator(new Uint8Array(points.flat()));
   yield;
   const edges = collect(getEdges(points, contours, delaunay))
+    // eslint-disable typescript/no-unsafe-type-assertion
     .map(
       ([p, q]) =>
         [
@@ -440,10 +441,13 @@ export function* roomKnowledge(roomName: string) {
           q.map(clamp(0, 49)).map(roundTo2Decimals),
         ] as Edge,
     )
+    // eslint-enable typescript/no-unsafe-type-assertion
     .filter(
       ([p, q]) =>
         !(
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion -- tuple from map
           (labelMap.get(...(p.map(Math.round) as Coordinates)) ?? 0) > 0 ||
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion -- tuple from map
           (labelMap.get(...(q.map(Math.round) as Coordinates)) ?? 0) > 0
         ),
     );

--- a/packages/bot/src/routines/room-knowledge.ts
+++ b/packages/bot/src/routines/room-knowledge.ts
@@ -187,8 +187,8 @@ function* contourTracing(
     yield;
     direction = (direction + 2) % 8;
     labelMap.set(...previous, label);
-    const [dx, next] = tracer(previous, direction, terrain, labelMap);
-    direction = dx + 4;
+    const [nextDx, next] = tracer(previous, direction, terrain, labelMap);
+    direction = nextDx + 4;
     if (coordinatesEquals(next, T) && coordinatesEquals(previous, S)) {
       break;
     }

--- a/packages/bot/src/routines/spawn-manager.ts
+++ b/packages/bot/src/routines/spawn-manager.ts
@@ -54,7 +54,7 @@ export function* spawnManager(): Routine {
       logger.error('No spawn found');
       return;
     }
-    return spawnCreep(
+    spawnCreep(
       spawn,
       'hauler',
       { home: spawn.room.name },
@@ -74,7 +74,7 @@ export function* spawnManager(): Routine {
       logger.error('No spawn found');
       return;
     }
-    return spawnCreep(spawn, 'miner', { slot }, bodyGenerator());
+    spawnCreep(spawn, 'miner', { slot }, bodyGenerator());
   };
 
   const spawnRemoteMiner = (slot: [...Coordinates, string]) => {
@@ -90,7 +90,7 @@ export function* spawnManager(): Routine {
       logger.error('No spawn found');
       return;
     }
-    return spawnCreep(spawn, 'miner', { slot }, bodyGenerator());
+    spawnCreep(spawn, 'miner', { slot }, bodyGenerator());
   };
 
   const spawnUpgrader = () => {
@@ -105,7 +105,7 @@ export function* spawnManager(): Routine {
       logger.error('No spawn found');
       return;
     }
-    return spawnCreep(spawn, 'upgrader', {}, bodyGenerator());
+    spawnCreep(spawn, 'upgrader', {}, bodyGenerator());
   };
 
   const spawnWorker = () => {
@@ -129,7 +129,7 @@ export function* spawnManager(): Routine {
       logger.error('No spawn found');
       return;
     }
-    return spawnCreep(spawn, 'worker', {}, bodyGenerator());
+    spawnCreep(spawn, 'worker', {}, bodyGenerator());
   };
 
   const spawnScout = () => {
@@ -141,7 +141,7 @@ export function* spawnManager(): Routine {
       logger.error('No spawn found');
       return;
     }
-    return spawnCreep(
+    spawnCreep(
       spawn,
       'scout',
       { home: spawn.room.name },

--- a/packages/bot/src/runner.ts
+++ b/packages/bot/src/runner.ts
@@ -4,5 +4,9 @@ import { createLogger } from './library';
 const logger = createLogger('coroutines');
 export const scheduler = new FIFOScheduler();
 export const { go, run } = createRunner(scheduler, (err) => {
-  logger.error(err as Error);
+  if (err instanceof Error) {
+    logger.error(err);
+  } else {
+    logger.error(new Error(String(err)));
+  }
 });

--- a/packages/bot/src/utils/ErrorMapper.ts
+++ b/packages/bot/src/utils/ErrorMapper.ts
@@ -29,7 +29,7 @@ export class ErrorMapper {
    */
   public static sourceMappedStackTrace(error: Error | string): string {
     const stack: string =
-      error instanceof Error ? (error.stack as string) : error;
+      error instanceof Error ? (error.stack ?? '') : error;
     const cached = this.cache.get(stack);
     if (cached) {
       return cached;

--- a/packages/bot/src/utils/index.ts
+++ b/packages/bot/src/utils/index.ts
@@ -30,6 +30,7 @@ export const groupBy = <T, K extends string | number>(
       ...acc,
       [key]: (acc[key] ?? ([] as T[])).concat(cur),
     };
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- empty seed for reduce accumulator
   }, {} as Record<K, T[]>);
 
 export const isDefined = <T>(value: T | undefined | null): value is T =>
@@ -69,6 +70,7 @@ export const getGuid = (): string => {
 
 export const objectEntries = <T extends string, V>(
   obj: Partial<Record<T, V>>
+// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Object.entries loses key type
 ): [T, V][] => Object.entries(obj).filter(isDefined) as [T, V][];
 
 export const max = <T>(arr: T[], map: (v: T) => number): T | null =>

--- a/packages/bot/src/utils/index.ts
+++ b/packages/bot/src/utils/index.ts
@@ -85,5 +85,5 @@ export const max = <T>(arr: T[], map: (v: T) => number): T | null =>
 export const min = <T>(arr: T[], map: (v: T) => number): T | null =>
   max(arr, (v) => -map(v));
 
-export const clamp = (min: number, max: number) => (value: number) =>
-  Math.max(min, Math.min(max, value));
+export const clamp = (lower: number, upper: number) => (value: number) =>
+  Math.max(lower, Math.min(upper, value));

--- a/packages/bot/src/utils/memory-hack.ts
+++ b/packages/bot/src/utils/memory-hack.ts
@@ -27,7 +27,7 @@ export const wrapWithMemoryHack = (fn: () => void) => {
 
     const visuals = new RoomVisual();
     visuals.text(
-      `Memory stringify: ${(end - start).toFixed(2).toString()}`,
+      `Memory stringify: ${(end - start).toFixed(2)}`,
       0,
       1.2,
       { font: 0.7, align: 'left' }

--- a/packages/bot/test/mocks.ts
+++ b/packages/bot/test/mocks.ts
@@ -20,6 +20,7 @@ class CostMatrix {
   }
 
   public serialize(): number[] {
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- Array.prototype.slice returns any
     return Array.prototype.slice.apply(
       new Uint32Array(this._bits.buffer),
     ) as number[];


### PR DESCRIPTION
## Summary

Address all 9 oxlint rules that were disabled with TODO comments during the initial migration. 8 rules enabled, 1 (`no-extraneous-class`) kept off with updated rationale. Rules are grouped into dedicated commits where possible, with trivial fixes batched together.

## Decisions & callouts

- **`no-extraneous-class` kept off** — `ErrorMapper` is a static-only class with cached state; refactoring to standalone functions would lose encapsulation. Comment updated from TODO to permanent rationale.
- **`no-unsafe-type-assertion`** — 15 of 17 violations are inherent (tuple casts from `.map()`, internal API access, `Object.keys`/`Object.entries` narrowing) and suppressed with inline disables. 2 were fixed: `instanceof` guard in `runner.ts`, nullish coalescing in `ErrorMapper.ts`.
- **`consistent-return` in spawn-manager** — the spawn helper functions returned `ScreepsReturnCode` from `spawnCreep()`, but no call site used the value. Fixed by dropping the `return` keyword, making the functions consistently `void`.
- **`no-shadow` renames** — 7 distinct renames: `sleep`→`existing`, `r`→`other`, `target`→`t`, `[x,y]`→`[cx,cy]`, `dx`→`nextDx`, `min/max`→`lower/upper`, `room`→`currentRoom`. The `currentRoom` rename applies to generator re-fetch loops where Screeps room objects go stale each tick — may warrant a dedicated abstraction in the future.
- **`no-unnecessary-type-arguments`** — 3 fixes remove redundant `Routine<void>` (void is the default). 1 lodash `_.pick` suppressed with inline disable (TS requires both type params for this overload).